### PR TITLE
Reduced iam privileges

### DIFF
--- a/cloudwatch-logs-exporter.tf
+++ b/cloudwatch-logs-exporter.tf
@@ -5,6 +5,10 @@ data "archive_file" "log_exporter" {
   output_path = "${path.module}/lambda/tmp/cloudwatch-to-s3.zip"
 }
 
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
 resource "random_string" "random" {
   length  = 8
   special = false
@@ -44,16 +48,21 @@ resource "aws_iam_role_policy" "log_exporter" {
       "Action": [
         "logs:CreateExportTask",
         "logs:Describe*",
-        "logs:ListTagsLogGroup",
+        "logs:ListTagsLogGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ssm:DescribeParameters",
         "ssm:GetParameter",
         "ssm:GetParameters",
         "ssm:GetParametersByPath",
-        "ssm:PutParameter",
-        "s3:*"
+        "ssm:PutParameter"
       ],
-      "Effect": "Allow",
-      "Resource": "*"
+      "Resource": "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/log-exporter-last-export/*",
+      "Effect": "Allow"
     },
     {
       "Action": [
@@ -61,7 +70,7 @@ resource "aws_iam_role_policy" "log_exporter" {
         "logs:CreateLogStream",
         "logs:PutLogEvents"
       ],
-      "Resource": "arn:aws:logs:*:*:*",
+      "Resource": "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/log-exporter-*",
       "Effect": "Allow"
     }
   ]


### PR DESCRIPTION
Used role had too many permissions. With this change only the least required
privileger are granted.

S3 access is not required in the exporter role but on the S3 bucket policy for
logs principal. This is terraform snippet that does the trick

{
    "Action": "s3:GetBucketAcl",
    "Effect": "Allow",
    "Resource": "${aws_s3_bucket.log.arn}",
    "Principal": { "Service": "logs.${data.aws_region.current.name}.amazonaws.com" }
},
{
    "Action": "s3:PutObject" ,
    "Effect": "Allow",
    "Resource": "${aws_s3_bucket.log.arn}/*",
    "Condition": { "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" } },
    "Principal": { "Service": "logs.${data.aws_region.current.name}.amazonaws.com" }