### PR TITLE
fix deprecated attribute warning

### DIFF
--- a/cloudwatch-logs-exporter.tf
+++ b/cloudwatch-logs-exporter.tf
@@ -13,7 +13,7 @@ resource "random_string" "random" {
   length  = 8
   special = false
   upper   = false
-  number  = false
+  numeric = false
 }
 
 resource "aws_iam_role" "log_exporter" {


### PR DESCRIPTION
Just a warning fix for `random_string` resource as `number` is now deprecated and replaced with `numeric`. See https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string#number

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
